### PR TITLE
Refines .gitignore with additional MacOS temp-files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,22 @@ cython_debug/
 # own additions
 tests/config.ini
 
+
+#MacOS
+.DS_Store
+.AppleDouble
+.LSOverride
+._*
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+*.icloud


### PR DESCRIPTION
I have updated the .gitignore file to include MacOS-specific files, such as .DS_Store and other system-generated files. This adjustment ensures that these unnecessary files are not tracked in the repository, allowing me to maintain a clean version control environment. By doing so, I can seamlessly work across all my machines without worrying about cluttering the repository with system-specific files.